### PR TITLE
Added types.d.ts file for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/staltz/callbag-basics.git"
   },
   "main": "index.js",
+  "types": "types.d.ts",
   "scripts": {
     "bundle": "$(npm bin)/browserify index.js -o dist/bundle.js",
     "bundle.min": "node minify.js",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,17 @@
+export { default as combine } from 'callbag-combine';
+export { default as concat } from 'callbag-concat';
+export { default as filter } from 'callbag-filter';
+export { default as flatten } from 'callbag-flatten';
+export { default as forEach } from 'callbag-for-each';
+export { default as fromEvent } from 'callbag-from-event';
+export { default as fromIter } from 'callbag-from-iter';
+export { default as fromObs } from 'callbag-from-obs';
+export { default as fromPromise } from 'callbag-from-promise';
+export { default as interval } from 'callbag-interval';
+export { default as map } from 'callbag-map';
+export { default as merge } from 'callbag-merge';
+export { default as pipe } from 'callbag-pipe';
+export { default as scan } from 'callbag-scan';
+export { default as share } from 'callbag-share';
+export { default as skip } from 'callbag-skip';
+export { default as take } from 'callbag-take';


### PR DESCRIPTION
This PR adds a types.d.ts file. I simply declared all of the exports that were already in index.js. Most of these packages already have types, so consumers should get them for free. Ones that don't will at least stop the compiler from complaining.