### PR TITLE
Add reactive-js to perf tests comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "callbag-basics",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/perf/combine.js
+++ b/perf/combine.js
@@ -7,6 +7,7 @@ var rxjs = require('rxjs')
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
+var reactiveJSObservable = require("@reactive-js/observable");
 
 var runners = require('./runners');
 var fromArray = require('./callbag-listenable-array');
@@ -51,6 +52,10 @@ var rx1 = rxjs.Observable.from(a);
 var rx2 = rxjs.Observable.from(a);
 var rx3 = rxjs.Observable.from(a);
 
+var reactivejs1 = reactiveJSObservable.fromArray(a);
+var reactivejs2 = reactiveJSObservable.fromArray(a);
+var reactivejs3 = reactiveJSObservable.fromArray(a);
+
 suite
   .add('cb-basics', function(deferred) {
     runners.runCallbag(deferred,
@@ -69,10 +74,20 @@ suite
     runners.runMost(deferred,
       most.combineArray(add3, [m1, m2, m3]).filter(even).drain());
   }, options)
+  .add("reactive-js", function(deferred) {
+    const { combineLatest, keep, map, pipe, } = require("@reactive-js/observable");
+    const observable = pipe(
+      combineLatest(reactivejs1, reactivejs2, reactivejs3), 
+      map(add3Arr), 
+      keep(even),
+    );
+    runners.runReactiveJS(deferred, observable);
+  }, options)
   .add('rx 5', function(deferred) {
     runners.runRx5(deferred,
       rxjs.Observable.combineLatest(rx1, rx2, rx3, add3).filter(even));
   }, options)
+
 
 runners.runSuite(suite);
 

--- a/perf/filter-map-fusion.js
+++ b/perf/filter-map-fusion.js
@@ -50,6 +50,11 @@ suite
   .add('most', function(deferred) {
     runners.runMost(deferred, most.from(a).map(add1).filter(odd).map(add1).map(add1).filter(even).reduce(sum, 0));
   }, options)
+  .add("reactive-js", function(deferred) {
+    const { fromArray, keep, map, pipe, scan } = require("@reactive-js/observable");
+    const observable = pipe(fromArray(a), map(add1), keep(odd), map(add1), map(add1), keep(even), scan(sum, 0));
+    runners.runReactiveJS(deferred, observable);
+  }, options)
   .add('rx 5', function(deferred) {
     runners.runRx5(deferred,
       rxjs.Observable.from(a).map(add1).filter(odd).map(add1).map(add1).filter(even).reduce(sum, 0));

--- a/perf/filter-map-reduce.js
+++ b/perf/filter-map-reduce.js
@@ -47,6 +47,11 @@ suite
   .add('most', function(deferred) {
     runners.runMost(deferred, most.from(a).filter(even).map(add1).reduce(sum, 0));
   }, options)
+  .add("reactive-js", function(deferred) {
+    const { fromArray, keep, map, pipe, scan, } = require("@reactive-js/observable");
+    const observable = pipe(fromArray(a), keep(even), map(add1), scan(sum, 0));
+    runners.runReactiveJS(deferred, observable);
+  }, options)
   .add('rx 5', function(deferred) {
     runners.runRx5(deferred,
       rxjs.Observable.from(a).filter(even).map(add1).reduce(sum, 0));

--- a/perf/fold.js
+++ b/perf/fold.js
@@ -45,6 +45,11 @@ suite
   .add('most', function(deferred) {
     runners.runMost(deferred, most.from(a).scan(sum, 0).reduce(passthrough, 0));
   }, options)
+  .add("reactive-js", function(deferred) {
+    const { fromArray, pipe, scan } = require("@reactive-js/observable");
+    const observable = pipe(fromArray(a), scan(sum, 0), scan(passthrough, 0));
+    runners.runReactiveJS(deferred, observable);
+  }, options)
   .add('rx 5', function(deferred) {
     runners.runRx5(deferred, rxjs.Observable.from(a).scan(sum, 0).reduce(passthrough, 0));
   }, options)

--- a/perf/merge.js
+++ b/perf/merge.js
@@ -63,6 +63,12 @@ suite
     var streams = a.map(most.from);
     runners.runMost(deferred, most.mergeArray(streams).reduce(sum, 0));
   }, options)
+  .add("reactive-js", function(deferred) {
+    const { fromArray, merge, pipe, scan, } = require("@reactive-js/observable");
+    const streams = a.map(x => fromArray(x));
+    const observable = pipe(merge(...streams), scan(sum, 0));
+    runners.runReactiveJS(deferred, observable);
+  }, options)
   .add('rx 5', function(deferred) {
     var streams = a.map(function(x) {return rxjs.Observable.from(x)});
     runners.runRx5(deferred,

--- a/perf/package-lock.json
+++ b/perf/package-lock.json
@@ -9,13 +9,54 @@
       "resolved": "https://registry.npmjs.org/@most/multicast/-/multicast-1.3.0.tgz",
       "integrity": "sha512-DWH8AShgp5bXn+auGzf5tzPxvpmEvQJd0CNsApOci1LDF4eAEcnw4HQOr2Jaa+L92NbDYFKBSXxll+i7r1ikvw==",
       "requires": {
-        "@most/prelude": "1.7.0"
+        "@most/prelude": "^1.4.0"
       }
     },
     "@most/prelude": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@most/prelude/-/prelude-1.7.0.tgz",
       "integrity": "sha512-OlDCH0+u2/ro/AHeAg63zvbvCsQC930hSKC9Kc1qSev1JkWK8Yk0HDHJ4o62HSjPwWGXEUZG1WhQKQh4ypreGA=="
+    },
+    "@reactive-js/disposable": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@reactive-js/disposable/-/disposable-0.0.6.tgz",
+      "integrity": "sha512-qzdQVHefudW+Hin120sbKo6ZghZEE68bIVV339Zs2rSN2w65osmWd+jJ4llb9uIAqeQ1hmgGELj9CiCO8gz2Kw=="
+    },
+    "@reactive-js/observable": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@reactive-js/observable/-/observable-0.0.6.tgz",
+      "integrity": "sha512-iNpz0fKa5Q9P89iesU5y3MmPmJPKgvH0lugyuiWSMzeA+yKFIMuSnpcX9yThNQmDEvp5eYMPXx/Vm7jNVQC2bQ==",
+      "requires": {
+        "@reactive-js/disposable": "^0.0.6",
+        "@reactive-js/rx": "^0.0.6",
+        "@reactive-js/scheduler": "^0.0.6"
+      }
+    },
+    "@reactive-js/rx": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@reactive-js/rx/-/rx-0.0.6.tgz",
+      "integrity": "sha512-pcHXQCTLJDbxoUOVbcljDDHsg05aKExTh3LpZ9eukmcZdSNVmkXSHdnjKFp0lIbP5mMajBbCAlPDnvAv0sGmXA==",
+      "requires": {
+        "@reactive-js/disposable": "^0.0.6",
+        "@reactive-js/scheduler": "^0.0.6"
+      }
+    },
+    "@reactive-js/scheduler": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@reactive-js/scheduler/-/scheduler-0.0.6.tgz",
+      "integrity": "sha512-hKRo6adjaHKHgP+p6RSKzUkqpgpvLyqahO0/apZ2lHxYlnCvaTcOjouggu7e9LXxJ5v6OD9Xyn1qcyVLaYr6XA==",
+      "requires": {
+        "@reactive-js/disposable": "^0.0.6"
+      }
+    },
+    "@reactive-js/schedulers": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@reactive-js/schedulers/-/schedulers-0.0.6.tgz",
+      "integrity": "sha512-CCjGz3Stthsyyu8bRCeTJTihm6o7ClUVh3r6GzZVXMVMLoC5df/Figd/yILXt/ZDztMMhAM3tK0JVSSCh97gYQ==",
+      "requires": {
+        "@reactive-js/disposable": "^0.0.6",
+        "@reactive-js/scheduler": "^0.0.6"
+      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -59,18 +100,11 @@
       "dev": true
     },
     "benchmark": {
-      "version": "github:bestiejs/benchmark.js#6c0a63c15f7338086923fab47952862ee9fae1c4",
-      "from": "github:bestiejs/benchmark.js#6c0a63c15f7338086923fab47952862ee9fae1c4",
+      "version": "github:bestiejs/benchmark.js#42f3b732bac3640eddb3ae5f50e445f3141016fd",
+      "from": "github:bestiejs/benchmark.js#master",
       "requires": {
-        "lodash": "4.17.4",
-        "platform": "1.3.5"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
+        "lodash": "^4.17.10",
+        "platform": "^1.3.5"
       }
     },
     "brace-expansion": {
@@ -79,7 +113,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -95,11 +129,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "concat-map": {
@@ -114,8 +148,8 @@
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       }
     },
     "define-properties": {
@@ -124,8 +158,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "duplexer": {
@@ -140,7 +174,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -149,11 +183,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -162,9 +196,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -179,13 +213,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       }
     },
     "find-up": {
@@ -194,8 +228,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "foreach": {
@@ -228,7 +262,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -237,7 +271,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "highland": {
@@ -245,7 +279,7 @@
       "resolved": "https://registry.npmjs.org/highland/-/highland-2.10.5.tgz",
       "integrity": "sha1-YAf9JPSDjZEXukG9zJjsO1S/3hg=",
       "requires": {
-        "util-deprecate": "1.0.2"
+        "util-deprecate": "^1.0.2"
       }
     },
     "hosted-git-info": {
@@ -266,7 +300,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -287,7 +321,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -319,7 +353,7 @@
       "resolved": "https://registry.npmjs.org/kefir/-/kefir-3.6.1.tgz",
       "integrity": "sha1-9M2dKs+XKnHy7Jn/9OAunvPDPr8=",
       "requires": {
-        "symbol-observable": "1.2.0"
+        "symbol-observable": "^1.0.1"
       }
     },
     "load-json-file": {
@@ -328,11 +362,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -346,8 +380,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "map-stream": {
@@ -362,7 +396,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "most": {
@@ -370,9 +404,9 @@
       "resolved": "https://registry.npmjs.org/most/-/most-1.1.1.tgz",
       "integrity": "sha1-dcy7TGGghrZ5TDeFg64BE7IPx7U=",
       "requires": {
-        "@most/multicast": "1.3.0",
-        "@most/prelude": "1.7.0",
-        "symbol-observable": "1.2.0"
+        "@most/multicast": "^1.2.3",
+        "@most/prelude": "^1.4.0",
+        "symbol-observable": "^1.0.2"
       }
     },
     "normalize-package-data": {
@@ -381,10 +415,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npm-run-all": {
@@ -393,16 +427,16 @@
       "integrity": "sha1-x+P69KoKWb8Nz8EmARZhUWkhcc8=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cross-spawn": "4.0.2",
-        "minimatch": "3.0.4",
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1",
-        "ps-tree": "1.1.0",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "shell-quote": "1.6.1",
-        "string.prototype.padend": "3.0.0"
+        "chalk": "^1.1.3",
+        "cross-spawn": "^4.0.0",
+        "minimatch": "^3.0.2",
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.1",
+        "ps-tree": "^1.0.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
       }
     },
     "object-assign": {
@@ -423,7 +457,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -432,7 +466,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-type": {
@@ -441,9 +475,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pause-stream": {
@@ -452,7 +486,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "pify": {
@@ -473,7 +507,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "platform": {
@@ -487,7 +521,7 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "3.3.4"
+        "event-stream": "~3.3.0"
       }
     },
     "pseudomap": {
@@ -502,9 +536,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -513,8 +547,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "rx": {
@@ -549,10 +583,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "spdx-correct": {
@@ -561,7 +595,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -582,7 +616,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "stream-combiner": {
@@ -591,7 +625,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "string.prototype.padend": {
@@ -600,9 +634,9 @@
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "strip-ansi": {
@@ -611,7 +645,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -620,7 +654,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "supports-color": {
@@ -651,8 +685,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "which": {
@@ -661,7 +695,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "xstream": {

--- a/perf/package.json
+++ b/perf/package.json
@@ -5,15 +5,13 @@
   "author": "Andre Staltz <andre+npm@staltz.com> (http://andre.staltz.com/)",
   "license": "MIT",
   "scripts": {
-    "filter-map-fusion": "node ./filter-map-fusion",
-    "filter-map-reduce": "node ./filter-map-reduce",
-    "flattenConcurrently": "node ./flattenConcurrently",
-    "merge": "node ./merge",
-    "combine": "node ./combine",
-    "fold": "node ./fold",
-    "flatten": "node ./flatten",
+    "filter-map-fusion": "NODE_ENV=production node ./filter-map-fusion",
+    "filter-map-reduce": "NODE_ENV=production node ./filter-map-reduce",
+    "merge": "NODE_ENV=production node ./merge",
+    "combine": "NODE_ENV=production node ./combine",
+    "fold": "NODE_ENV=production node ./fold",
     "dataflow": "node ./dataflow",
-    "start": "npm-run-all filter-map-reduce merge combine flatten fold dataflow flattenConcurrently filter-map-fusion"
+    "start": "npm-run-all filter-map-reduce merge combine fold dataflow filter-map-fusion"
   },
   "dependencies": {
     "rxjs": "5.5.x",
@@ -24,7 +22,10 @@
     "lodash": "4.17.x",
     "most": "1.1.x",
     "rx": "4.1.x",
-    "xstream": "11"
+    "xstream": "11",
+    "@reactive-js/rx": "0.0.6",
+    "@reactive-js/observable": "0.0.6",
+    "@reactive-js/schedulers": "0.0.6"
   },
   "devDependencies": {
     "npm-run-all": "^3.1.2"

--- a/perf/runners.js
+++ b/perf/runners.js
@@ -12,6 +12,7 @@ exports.runKefir       = runKefir;
 exports.kefirFromArray = kefirFromArray;
 exports.runBacon       = runBacon;
 exports.runHighland    = runHighland;
+exports.runReactiveJS  = runReactiveJS; 
 
 exports.getIntArg      = getIntArg;
 exports.getIntArg2     = getIntArg2;
@@ -170,6 +171,16 @@ function runHighland(deferred, highlandStream) {
 
     deferred.resolve(z);
   });
+}
+
+var {connect} = require("@reactive-js/rx");
+var {createPerfTestingScheduler} =  require("@reactive-js/schedulers");
+
+function runReactiveJS(deferred, stream) {
+  var scheduler = createPerfTestingScheduler();
+  connect(stream, scheduler);
+  scheduler.run();
+  deferred.resolve();
 }
 
 function padl(n, s) {


### PR DESCRIPTION
I just released an alpha of reactive-js (https://github.com/bordoley/reactive-js), a new reactive programming library i've been working on that deeply integrates a cooperate multi-tasking scheduler into the core subscriber type. My main goal when starting the project was to update the Observable contract to play nicely with React's new multitasking scheduler, but pleasantly to my surprise I realized that it also resulted in very fast synchronous observables when run on a virtual time scheduler. Results below are from a mid-2014 macbook pro. 

The library API is still a little unstable, so I'm not sure that I'd merge this yet, but I wanted to share the results at least. 

funrecordss-MacBook-Pro:perf funrecords$ npm run start
```
> perf@0.0.0 start /Users/funrecords/Desktop/Code/callbag-basics/perf
> npm-run-all filter-map-reduce merge combine fold dataflow filter-map-fusion


> perf@0.0.0 filter-map-reduce /Users/funrecords/Desktop/Code/callbag-basics/perf
> NODE_ENV=production node ./filter-map-reduce

filter -> map -> reduce 1000000 integers
-----------------------------------------------
cb-basics    34.97 op/s ±  1.27%   (44 samples)
xstream      14.58 op/s ±  0.87%   (68 samples)
most        513.28 op/s ±  0.53%   (81 samples)
reactive-js  261.07 op/s ±  0.62%   (79 samples)
rx 5         35.39 op/s ±  2.01%   (80 samples)
rx 4          2.06 op/s ±  1.00%   (15 samples)
kefir        11.39 op/s ± 10.36%   (58 samples)
bacon         1.67 op/s ±  4.82%   (13 samples)
highland      4.18 op/s ±  2.50%   (24 samples)
lodash       20.99 op/s ±  0.60%   (39 samples)
Array        17.92 op/s ±  2.28%   (48 samples)
-----------------------------------------------

> perf@0.0.0 merge /Users/funrecords/Desktop/Code/callbag-basics/perf
> NODE_ENV=production node ./merge

merge 100000 x 10 streams
-----------------------------------------------
cb-basics    31.18 op/s ±  1.12%   (72 samples)
xstream      22.62 op/s ±  1.66%   (56 samples)
most        205.51 op/s ±  0.97%   (81 samples)
reactive-js  265.12 op/s ±  0.59%   (79 samples)
rx 5         62.68 op/s ±  0.45%   (72 samples)
rx 4          1.67 op/s ±  0.89%   (13 samples)
kefir        12.50 op/s ±  1.21%   (60 samples)
bacon         1.65 op/s ±  4.49%   (13 samples)
lodash       17.66 op/s ±  2.02%   (48 samples)
Array        40.15 op/s ±  1.13%   (53 samples)
-----------------------------------------------

> perf@0.0.0 combine /Users/funrecords/Desktop/Code/callbag-basics/perf
> NODE_ENV=production node ./combine

combine(add3) -> filter 500000 x 3 integers
-----------------------------------------------
cb-basics    18.93 op/s ±  0.76%   (83 samples)
xstream      19.20 op/s ±  0.84%   (62 samples)
most         70.27 op/s ±  0.56%   (79 samples)
reactive-js   40.42 op/s ±  0.56%   (64 samples)
rx 5         32.27 op/s ±  1.82%   (74 samples)
-----------------------------------------------

> perf@0.0.0 fold /Users/funrecords/Desktop/Code/callbag-basics/perf
> NODE_ENV=production node ./fold

scan -> reduce 1000000 integers
-----------------------------------------------
cb-basics    21.34 op/s ±  0.77%   (53 samples)
xstream      13.39 op/s ±  1.10%   (64 samples)
most        331.09 op/s ±  0.35%   (82 samples)
reactive-js   33.62 op/s ±  3.22%   (77 samples)
rx 5         19.90 op/s ±  2.58%   (51 samples)
rx 4          1.99 op/s ±  1.43%   (14 samples)
kefir        14.96 op/s ±  1.12%   (39 samples)
bacon         1.12 op/s ±  9.35%   (10 samples)
highland      4.40 op/s ±  2.07%   (26 samples)
lodash        6.72 op/s ± 10.51%   (19 samples)
Array         6.30 op/s ±  9.56%   (14 samples)
-----------------------------------------------

> perf@0.0.0 dataflow /Users/funrecords/Desktop/Code/callbag-basics/perf
> node ./dataflow

dataflow for 1000000 source events
-----------------------------------------------
cb-basics     6.73 op/s ±  2.48%   (36 samples)
xstream       4.23 op/s ±  1.55%   (25 samples)
most         14.40 op/s ±  1.05%   (67 samples)
rx 5          6.55 op/s ±  0.80%   (35 samples)
rx 4          0.65 op/s ±  1.69%    (8 samples)
bacon         0.77 op/s ±  6.98%    (8 samples)
-----------------------------------------------

> perf@0.0.0 filter-map-fusion /Users/funrecords/Desktop/Code/callbag-basics/perf
> NODE_ENV=production node ./filter-map-fusion

filter -> map -> fusion 1000000 integers
-----------------------------------------------
cb-basics    19.88 op/s ±  0.79%   (35 samples)
xstream      16.06 op/s ±  0.81%   (73 samples)
most        105.15 op/s ±  0.41%   (79 samples)
reactive-js   42.93 op/s ±  3.49%   (68 samples)
rx 5         18.09 op/s ±  0.90%   (81 samples)
rx 4          1.81 op/s ±  0.94%   (13 samples)
kefir         8.17 op/s ±  1.17%   (42 samples)
bacon         1.34 op/s ±  4.55%   (11 samples)
highland      2.39 op/s ±  1.23%   (16 samples)
lodash       13.84 op/s ±  1.20%   (38 samples)
Array        12.89 op/s ±  1.74%   (36 samples)
-----------------------------------------------
funrecordss-MacBook-Pro:perf funrecords$ 
```